### PR TITLE
Fix 3 dead neptune.ai links in LLM Engineer's Handbook reading list

### DIFF
--- a/src/LLM-Engineers-Handbook/拓展阅读资料清单/第2章 工具与安装.md
+++ b/src/LLM-Engineers-Handbook/拓展阅读资料清单/第2章 工具与安装.md
@@ -8,7 +8,7 @@
 
 [3] Czakon, J. (2024, September 25). ML Experiment Tracking: What It Is, Why It Matters, and How to Implement It. neptune.ai.
 
-<https://neptune.ai/blog/ml-experiment-tracking>
+<https://web.archive.org/web/20251127141526/https://neptune.ai/blog/ml-experiment-tracking>
 
 [4] Hopsworks. (n.d.). ML Artifacts (ML Assets)? Hopsworks.
 
@@ -24,7 +24,7 @@
 
 [7] Kaewsanmua, K. (2024, January 3). Best Machine Learning Workflow and Pipeline Orchestration Tools. neptune.ai.
 
-<https://neptune.ai/blog/best-workflow-and-pipeline-orchestration-tools>
+<https://web.archive.org/web/20251023112045/https://neptune.ai/blog/best-workflow-and-pipeline-orchestration-tools>
 
 [8] MongoDB. (n.d.). What is NoSQL? NoSQL databases explained.
 
@@ -36,7 +36,7 @@
 
 [10] Oladele, S. (2024, August 29). ML Model Registry: The Ultimate Guide. neptune.ai.
 
-<https://neptune.ai/blog/ml-model-registry>
+<https://web.archive.org/web/20251005125802/https://neptune.ai/blog/ml-model-registry>
 
 [11] Schwaber-Cohen, R. (n.d.). What is a Vector Database & How Does it Work? Use Cases + Ex
 


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 3 dead links in the chapter 2 reading list (`src/LLM-Engineers-Handbook/拓展阅读资料清单/第2章 工具与安装.md`), pointing them to Wayback Machine snapshots of the original articles.
All archive links are pinned to the last working (HTTP 200) Wayback capture before the redirect took effect.